### PR TITLE
Fx oanda historical

### DIFF
--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from time import time
 
 import pandas as pd
-import re
 
 from oandapyV20 import API, V20Error
 import oandapyV20.endpoints.instruments as instruments

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -579,13 +579,10 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
 
             # print(response)
 
-            if not response:
+            if not (response and "candles" in response):
                 continue
 
             candles = response['candles']
-
-            if not candles:
-                continue
 
             # print(candles)
 

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -233,16 +233,11 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
         return pn
 
     def _read_historical_currencypair_rates(self, start, end, freq=None,
-                                            quote_currency=None, base_currency=None,
+                                            quote_currency="USD", base_currency="EUR",
                                             candleFormat=None, reversed=False,
                                             access_credential=None, session=None):
         session = _init_session(session)
         start, end = _sanitize_dates(start, end)
-
-        if base_currency is None:
-            base_currency = "EUR"
-        if quote_currency is None:
-            quote_currency = "USD"
 
         currencyPair = "%s_%s" % (base_currency, quote_currency)
 

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -601,10 +601,7 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
     def _get_periods(self, start, end, delta):
         current_start = start
         while current_start < end:
-            if current_start > end:
-                current_end = end
-            else:
-                current_end = current_start + delta
+            current_end = current_start + delta
 
             yield current_start, current_end
 

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -34,15 +34,15 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
     """
         Historical Currency Pair Reader using  OANDA's REST v20 API.
         See details at http://developer.oanda.com/rest-live-v20/instrument-ep/
-        symbols : string or Dict of strings.
+        symbols : string or List of strings.
             Each string is a currency pair with format BASE_QUOTE. Eg: ["EUR_USD", "JPY_USD"]
-        symbolsTypes: Dict of strings.
+        symbolsTypes: List of strings.
             Each string represent the type of instrument to fetch data for. Eg: For symbols=["EUR_USD", "EUR_JPY"] then symbolsTypes=["currency", "currency"]
             Valid values: currency
         start: string
-            Date to begin fetching curerncy pair, in RFC3339 ("%Y-%m-%dT%H:%M:%SZ)  # Eg: "2014-03-21T17:41:00Z"
+            Date to begin fetching currency pair, in RFC3339 ("%Y-%m-%dT%H:%M:%SZ)  # Eg: "2014-03-21T17:41:00Z"
         end: string
-            Date to end fetching curerncy pair, in RFC3339 ("%Y-%m-%dT%H:%M:%SZ)  # Eg: "2014-03-21T17:41:00Z"
+            Date to end fetching currency pair, in RFC3339 ("%Y-%m-%dT%H:%M:%SZ)  # Eg: "2014-03-21T17:41:00Z"
         freq: string or Pandas's DateOffset
             Frequency or periodicity of the candlesticks to be retrieved
             Valid values are the following Panda's Offset Aliases (http://pandas.pydata.org/pandas-docs/stable/timeseries.html):
@@ -77,7 +77,7 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
             Default: See DEFAULT_CANDLE_FORMAT
         access_credential: Dict of strings
             Credential to query the api
-            credential["accountType"]="practise". Mandatory. Valid values: practice, live
+            credential["accountType"]="practice". Mandatory. Valid values: practice, live
             credential["apiToken"]="Your OANDA API token". Mandatory. Valid value: See your OANDA Account's API Token
 
         Returns:

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -123,7 +123,7 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
         "1M": "M"
     }
 
-    def __init__(self, symbols, symbolsTypes=None,
+    def __init__(self, symbols=["EUR_USD"], symbolsTypes=["currency"],
                  start=None, end=None,
                  freq=None, candleFormat=None,
                  session=None,
@@ -138,15 +138,12 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
             self.reader_compatible = False
 
         self.symbols = symbols
-        if symbols is None:
-            self.symbols = ["EUR_USD"]
-
         if type(symbols) is str:
             self.symbols = [symbols]
 
         self.symbolsTypes = symbolsTypes
-        if symbolsTypes is None:
-            self.symbolsTypes = ["currency"]
+        if type(symbolsTypes) is str:
+            self.symbolsTypes = [symbolsTypes]
 
         if len(self.symbols) != len(self.symbolsTypes):
             self.symbolsTypes = ["currency" for x in self.symbols]

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -561,24 +561,21 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
                 response = oanda.request(request)
                 current_start = current_end
                 includeCandleOnStart = False
-            except Exception as error:
-                isExceedResultsLimitError = re.findall(
-                    "The results returned satisfying the query exceeds the maximum size", str(error))
-                isExceedResultsLimitError = True if len(
-                    isExceedResultsLimitError) else False
 
-                if isExceedResultsLimitError:
-                    # Problem: OANDA caps returned range to 5000 results max
-                    # Solution: Reduce requested date interval to return less
-                    # than 5000 results
+            except V20Error as error:
+                # Problem: OANDA caps returned range to 5000 results max
+                # Solution: Reduce requested date interval to return less
+                # than 5000 results
+                if "Maximum value for 'count' exceeded" in error.msg:
                     current_duration /= 2
                     continue
-                else:
-                    if type(error) is V20Error:
-                        print("Request failed with code: " + str(error.code) + " and message: " + str(error.msg))
-                    else:
-                        print("ERROR OANDA: " + str(error))
+                else: # re-raise
+                    print("ERROR OANDA: " + str(error))
                     raise error
+
+            except Exception as error:
+                print("ERROR : " + error)
+                raise error
 
             # print(response)
 

--- a/pandas_datareader/oandarest.py
+++ b/pandas_datareader/oandarest.py
@@ -618,8 +618,8 @@ class OANDARestHistoricalInstrumentReader(_BaseReader):
 
     def _reverse_pair(s, sep="_"):
         lst = s.split(sep)
-        return sep.join([lst[1], lst[0]])
+        return sep.join(lst[::-1])
 
     def _split_currency_pair(self, s, sep="_"):
         lst = s.split(sep)
-        return (lst[0], lst[1])
+        return tuple(lst)

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,9 @@ def readme():
         return f.read()
 
 INSTALL_REQUIRES = (
-    ['pandas', 'requests>=2.3.0', 'requests-file', 'requests-ftp', 'oandapyV20>=0.1.0']
+    ['pandas', 'requests>=2.3.0', 'requests-file', 'requests-ftp', 'oandapyV20>=0.2.0']
 )
 
-DEPENDENCY_LINKS = (
-    ['https://github.com/hootnot/oanda-api-v20/archive/af035ef99ae73d998172569bc702326d2df96d4e.zip#egg=oandapyV20-0.1.0']
-)
 
 setup(
     name=NAME,
@@ -57,7 +54,6 @@ setup(
     ],
     keywords='data',
     install_requires=INSTALL_REQUIRES,
-    dependency_links=DEPENDENCY_LINKS,
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     test_suite='tests',
     zip_safe=False,


### PR DESCRIPTION
Corrected some typos
Made some changes in the code

It seems that "currency" is the only symbolsType you accept in the code.
Why pass it as a parameter ? In that case I would suggest to skip the parameter and set the symbolsTypes  as you do in the list comprehension:
```python
   self.symbolsType =  ["currency" for x in self.symbols]
```
If the symbolsType parameter is important in the code, maybe it is better to pass the symbols as a dict with the symbolsType:

```python
   # pass  parameter (default type is currency in case not specified)
   symbols = [{ "symbol": "EUR_USD"}, { "symbol": "EUR_JPY"} , { "symbol": "DE30_EUR", "type": "index"}]

   # in __init__
   self.symbols = []
   self.symbolsTypes = []
   for S in symbols:
       self.symbols.append(S["symbol"])
       self.symbolsTypes.append("currency" if "type" not in S else S["type"]

```

